### PR TITLE
Dutch translation

### DIFF
--- a/locales/nl-NL/general.json
+++ b/locales/nl-NL/general.json
@@ -78,7 +78,7 @@
     "version": "Versie"
   },
   "nav": {
-    "contribute": "Help mee",
+    "contribute": "Indienen",
     "explore": "Ontdek",
     "help": "Help",
     "news": "Nieuws",

--- a/locales/nl-NL/general.json
+++ b/locales/nl-NL/general.json
@@ -53,7 +53,7 @@
     "meetsRequirements": "Voldoet aan de eisen",
     "moreInfo": "Meer informatie",
     "multiplayer": "Multiplayer",
-    "native": "Ondersteund",
+    "native": "Native",
     "negative": "Nee",
     "notFound": "Niet gevonden",
     "note": "Notitie",

--- a/locales/nl-NL/general.json
+++ b/locales/nl-NL/general.json
@@ -1,0 +1,143 @@
+{
+  "auth": {
+    "genericSignIn": "Inloggen",
+    "headline": "Steam-authenticatie",
+    "loggedInAs": "Ingelogd als {{username}}",
+    "notLoggedIn": "Niet ingelogd",
+    "steamSignIn": "Inloggen met Steam",
+    "unlink": "Ontkoppel account"
+  },
+  "content": {
+    "followingPost": "Volgend bericht",
+    "previousPost": "Vorig bericht"
+  },
+  "contextualInfo": {
+    "hoursPlayed": "{{context}} uren gespeeld",
+    "peakPlayers": "{{context}} spelers op zijn hoogtepunt",
+    "positiveRating": "{{context}}% positieve recensies",
+    "recentReportCount": "{{context}} recensies met de laatste twee Proton versies"
+  },
+  "footer": {
+    "description": "{{name}} is met passie gemaakt door [@bdefore]({{link}}) en een toegewijde gebruikersgroep.",
+    "feedbackPrompt": "Heb je opmerkingen? Join onze Discord!",
+    "legal": "Deze website heeft geen banden met Valve Software. Alle spelafbeeldingen en logo's zijn eigendom van hun respectievelijke eigenaren."
+  },
+  "libraryLoader": {
+    "errorLoadingGames": "Er is een fout opgetreden bij het laden van jouw spellen. Zorg ervoor dat je profiel en de speldetails openbaar zijn op dit account!",
+    "gameTotal": "{{count}} spellen geladen vanuit jouw bibliotheek.",
+    "note": "Deze functie gebruikt de Steam Web API om jouw accountinformatie op te halen, zoals je ID, profielnaam en afbeelding. Zorg ervoor dat 'Mijn profiel' in je [Steam Privacyinstellingen]({{link}}) op 'Openbaar' staat. 'Speldetails' hoeft niet per sé niet op openbaar te staan, maar dit is wel nodig als je een gepersonaliseerde Ontdek-pagina wilt hebben en als je je speelduur in je recensies wilt laten zien.",
+    "refresh": "Verversen"
+  },
+  "misc": {
+    "addYourReport": "Recensie toevoegen",
+    "affirmative": "Ja",
+    "any": "Elke",
+    "areYouSure": "Weet je het zeker?",
+    "cancel": "Annuleer",
+    "chipset": "Chipset",
+    "conjunction": "en",
+    "discard": "Weggooien",
+    "dismiss": "Afwijzen",
+    "distro": "Distributie",
+    "driver": "Stuurprogramma",
+    "execute": "Speel",
+    "feedbackPrompt": "Opmerkingen? Laat ons weten op [Discord]({{link}})",
+    "filter": "Filter",
+    "filteringSettings": "Filter-instellingen",
+    "games": "Spellen",
+    "hide": "Verberg {{what}}",
+    "include": "Voeg toe",
+    "install": "Installeer",
+    "joinUsPrompt": "Join onze Discord!",
+    "lastContentRefreshTime": "Laatst verversd {{time}} geleden",
+    "meetsRequirements": "Voldoet aan de eisen",
+    "moreInfo": "Meer informatie",
+    "multiplayer": "Multiplayer",
+    "native": "Ondersteund",
+    "negative": "Nee",
+    "notFound": "Niet gevonden",
+    "note": "Notitie",
+    "overall": "Gezamenlijk",
+    "pending": "Wachtend",
+    "preferences": "Instelligen",
+    "provisional": "Voorlopig",
+    "published": "Gepubliceerd",
+    "rated": "Beoordeeld",
+    "report": "Recensie",
+    "reports": "Recensies",
+    "reset": "Resetten",
+    "save": "Opslaan",
+    "saved": "{{what}} opgeslagen",
+    "show": "Laat {{what}} zien",
+    "showAll": "Laat alles zien",
+    "showMore": "Laat meer zien",
+    "skip": "Overslaan",
+    "tier": "Ondersteuningsniveau",
+    "total": "Totaal",
+    "unknown": "Onbekend",
+    "version": "Versie"
+  },
+  "nav": {
+    "contribute": "Help mee",
+    "explore": "Ontdek",
+    "help": "Help",
+    "news": "Nieuws",
+    "profile": "Profiel",
+    "search": "Zoek spellen...",
+    "stats": "Statistieken"
+  },
+  "pagination": {
+    "next": "Volgende pagina",
+    "previous": "Vorige pagina",
+    "summary": "Resultaten {{from}} tot {{to}} van {{total}}"
+  },
+  "preferences": {
+    "headline": "Instellingen",
+    "intro": "ProtonDB laat de Steam gebruikersnaam van de auteur naast de recensie zien. Jouw unieke Steam ID wordt niet vrijgegeven in deze recensiedata. Als je om privacyredenen je Steam gebruikersnaam niet wilt laten zien kun je hier een schuilnaam invullen. Deze schuilnaam zal toegepast worden na de volgende verversing.",
+    "questions": {
+      "customName": {
+        "additionalNotes": {
+          "label": "Schuilnaam"
+        },
+        "options": {
+          "custom": "Een schuilnaam",
+          "keepSteam": "Mijn Steam gebruikersnaam ({{steamNickname}})"
+        },
+        "prompt": "Jouw openbare naam"
+      },
+      "language": {
+        "prompt": "Taal"
+      },
+      "performanceMode": {
+        "prompt": "Gebruik je liever een prestatievriendelijke versie van de website?"
+      }
+    }
+  },
+  "profile": {
+    "exploreLibrary": "Je kan jouw bibliotheek sorteren met de volgende opties:",
+    "inYourLibrary": "In jouw bibliotheek",
+    "libraryTags": {
+      "byHoursPlayed": "Op basis van jouw gespeelde uren",
+      "byPlayerCount": "Op basis van populariteit",
+      "byProtonDbRating": "Op basis van ProtonDB waardering",
+      "bySteamDbScore": "Op basis van SteamDB score",
+      "headline": "Deze onderwerpen zijn veelvoorkomend in jouw bibliotheek:",
+      "lackReportsByHoursPlayed": "Gebrek aan recensies op basis van jouw gespeelde uren\n",
+      "lackReportsByPlayerCount": "Gebrek aan recensies op basis van populariteit",
+      "lackReportsBySteamDbScore": "Gebrek aan recensies op basis van SteamDB score"
+    },
+    "notInYourLibrary": "Niet in jouw bibliotheek",
+    "yourContributions": "Jouw recensies"
+  },
+  "reports": {
+    "clear": "Clear",
+    "filteredOutCount": "{{count}} verborgen door filter",
+    "filteredOutHeadline": "De volgende {{count}} recensies komen niet overeen met jouw filter(s) voor {{filters}}",
+    "superceded": "Er is een nieuwere recensie van deze auteur",
+    "zeroStateMessage": "Geen recensies",
+    "zeroStateMessageWithFilters": "Geen recensies komen overeen met deze filters"
+  },
+  "search": {
+    "resultsHeader": "Zoekresultaten voor {{q}}"
+  }
+}

--- a/locales/nl-NL/proton-report.json
+++ b/locales/nl-NL/proton-report.json
@@ -1,0 +1,510 @@
+{
+  "appSelection": {
+    "caution": "Waarschuwing!",
+    "helperText": "Je kunt ook een hyperlink of een App ID hierin plakken en wij zullen het proberen te vinden.",
+    "notFound": "Er kan geen spel gevonden worden met App ID {{query}}. Dit kan gebeuren als het ID ongeldig is of om één van de volgende redenen; het spel is verwijderd van de Steam winkel, het is niet als een 'game' getypeerd, of het is niet beschikbaar in jouw land.",
+    "placeholder": "Voer een naam in van een spel uit jouw Steam-bibliotheek...",
+    "previousReportsExist": "Je hebt al eerder een recensie over dit spel geschreven",
+    "runsNativeWarning": "Het geselecteerde spel ondersteunt Linux! Zorg ervoor dat u het spel met Steam Play uitvoert en niet met de standaard Linux-ondersteunende versie. Steam gebruikt standaard niet Steam Play om het spel te starten, maar [je kan dit wel dwingen]({{link}})."
+  },
+  "audioFaults": {
+    "legend": "Audio",
+    "options": {
+      "borked": {
+        "long": "Werkt totaal niet",
+        "short": "Werkt niet"
+      },
+      "crackling": {
+        "long": "Krakend geluid",
+        "short": "Krakend geluid"
+      },
+      "lowQuality": {
+        "long": "Merkbare achteruitgang van de kwaliteit",
+        "short": "Lage kwaliteit"
+      },
+      "missing": {
+        "long": "Sommige audiofragmenten ontbreken",
+        "short": "Ontbreekt"
+      },
+      "other": {
+        "long": "Ander probleem",
+        "short": "Ander probleem"
+      },
+      "outOfSync": {
+        "long": "Audio liep niet synchroon met het spel",
+        "short": "Niet gesynchroniseerd"
+      }
+    },
+    "prompt": "Had je problemen met de audio?"
+  },
+  "borked": {
+    "headline": "Dat is jammer!",
+    "intro": "Je hebt in je recensie vermeld dat de game onspeelbaar is. Voordat je de recensie publiceert wil je misschien onze [Veelgestelde vragen en probleemoplossing]({{link}}) pagina bekijken."
+  },
+  "customizationsUsed": {
+    "additionalNotes": {
+      "label": "Meer details",
+      "placeholder": "Explanation or link to blog post or Github repository"
+    },
+    "legend": "Aanpassingen",
+    "options": {
+      "customPrefix": {
+        "long": "Een aangepaste Wine prefix",
+        "short": "Aangepaste Prefix"
+      },
+      "customProton": {
+        "long": "Een aangepaste versie van Proton",
+        "short": "Aangepaste Proton"
+      },
+      "lutris": {
+        "long": "Lutris installatiescript",
+        "short": "Lutris"
+      },
+      "mediaFoundation": {
+        "long": "Media Foundation DLL (mf-install)",
+        "short": "Media Foundation DLL"
+      },
+      "native2Proton": {
+        "long": "Native2Proton",
+        "short": "Native2Proton"
+      },
+      "notListed": {
+        "long": "Een andere aanpassing die niet in deze lijst staat",
+        "short": "Niet in deze lijst"
+      },
+      "protonfixes": {
+        "long": "protonfixes",
+        "short": "protonfixes"
+      },
+      "protontricks": {
+        "long": "protontricks",
+        "short": "protontricks"
+      },
+      "winetricks": {
+        "long": "winetricks",
+        "short": "winetricks"
+      }
+    },
+    "prompt": "Welke aanpassing(en) heb je gemaakt?"
+  },
+  "duration": {
+    "legend": "Speelduur",
+    "options": {
+      "aboutAnHour": {
+        "long": "een uur",
+        "short": "een uur"
+      },
+      "lessThanAnHour": {
+        "long": "< 1 uur",
+        "short": "< 1 uur"
+      },
+      "lessThanFifteenMinutes": {
+        "long": "< 15 minuten",
+        "short": "< 15 minuten"
+      },
+      "moreThanTenHours": {
+        "long": "> 10 uur",
+        "short": "> 10 uur"
+      },
+      "severalHours": {
+        "long": "2+ uur",
+        "short": "2+ uur"
+      }
+    },
+    "prompt": "Hoe lang heb je het spel gespeeld?"
+  },
+  "extra": {
+    "additionalNotes": {
+      "label": "Extra opmerkingen",
+      "placeholder": "Voer hier opmerkingen in."
+    },
+    "prompt": "Heeft u opmerkingen die u zou willen toevoegen die nog niet in eerdere vragen behandeld zijn?"
+  },
+  "graphicalFaults": {
+    "legend": "Beeld",
+    "options": {
+      "heavyArtifacts": {
+        "long": "Zware of veelvoorkomende beeldverstoringen",
+        "short": "Veel beeldverstoringen"
+      },
+      "minorArtifacts": {
+        "long": "Kleine of zeldzame beeldverstoringen",
+        "short": "Enkele beeldverstoringen"
+      },
+      "missingTextures": {
+        "long": "Er ontbreken textures",
+        "short": "Er ontbreken textures"
+      },
+      "other": {
+        "long": "Ander probleem",
+        "short": "Ander probleem"
+      }
+    },
+    "prompt": "Heeft u vermindering van grafische kwaliteit opgemerkt?"
+  },
+  "graphicsApiSelection": {
+    "legend": "Grafische API",
+    "options": {
+      "d3d": {
+        "long": "Direct3D",
+        "short": "Direct3D"
+      },
+      "ogl": {
+        "long": "OpenGL",
+        "short": "OpenGL"
+      },
+      "unsure": {
+        "long": "De API die het spel standaard ook gebruikt",
+        "short": "Standaard"
+      },
+      "vk": {
+        "long": "Vulkan",
+        "short": "Vulkan"
+      }
+    },
+    "prompt": "Welke grafische API gebruikte je om het spel uit te voeren?"
+  },
+  "inputFaults": {
+    "legend": "Invoer",
+    "options": {
+      "bounding": {
+        "long": "Invoergrenzen waren incorrect",
+        "short": "Invoergrenzen waren incorrect"
+      },
+      "controllerMapping": {
+        "long": "Controller(s) waren incorrect aangewezen",
+        "short": "Fout aangewezen"
+      },
+      "controllerNotDetected": {
+        "long": "Controller(s) niet gedetecteerd",
+        "short": "Controller was niet gedetecteerd"
+      },
+      "controllerNotResponsive": {
+        "long": "Controller(s) waren gedetecteerd maar reageerde(n) niet",
+        "short": "Responsiveness"
+      },
+      "drifting": {
+        "long": "De invoerassen dreven af",
+        "short": "Afdrijving"
+      },
+      "inaccuracy": {
+        "long": "Invoer was niet accuraat",
+        "short": "Niet accuraat"
+      },
+      "lag": {
+        "long": "Invoer was vertraagd",
+        "short": "Vertraging"
+      },
+      "other": {
+        "long": "Andere reden",
+        "short": "Andere reden"
+      }
+    },
+    "prompt": "Had je problemen met je muis, controller, of een ander invoerapparaat?"
+  },
+  "installs": {
+    "legend": "Installeren",
+    "prompt": "Lukte het om het spel installeren?"
+  },
+  "isImpactedByAntiCheat": {
+    "legend": "Anti-Cheat",
+    "options": {
+      "battleEye": {
+        "long": "BattlEye",
+        "short": "BattlEye"
+      },
+      "easyAntiCheat": {
+        "long": "Easy Anti Cheat",
+        "short": "EAC"
+      },
+      "other": {
+        "long": "Andere anti-cheat",
+        "short": "Andere anti-cheat"
+      }
+    },
+    "prompt": "Wordt het spel gehinderd door anti-cheat software?"
+  },
+  "isMultiplayerImportant": {
+    "prompt": "Is multiplayer een belangrijk aspect van het spel?"
+  },
+  "launchFlagsUsed": {
+    "additionalNotes": {
+      "label": "Meer details",
+      "placeholder": "Waarmee heeft dit geholpen?"
+    },
+    "legend": "Proton-opties",
+    "options": {
+      "disableD3d10": {
+        "long": "Deactiveer D3D10 (PROTON_NO_D3D10)",
+        "short": "Deactiveer D3D10"
+      },
+      "disableD3d11": {
+        "long": "Deactiveer D3D11 (PROTON_NO_D3D11)",
+        "short": "Deactiveer D3D11"
+      },
+      "disableEsync": {
+        "long": "Deactiveer Esync (PROTON_NO_ESYNC)",
+        "short": "Deactiveer Esync"
+      },
+      "disableFsync": {
+        "long": "Deactiveer Fsync (PROTON_NO_FSYNC)",
+        "short": "Deactiveer Fsync"
+      },
+      "fullscreenIntegerScaling": {
+        "long": "Fullscreen Integer Scaling (WINE_FULLSCREEN_INTEGER_SCALING)",
+        "short": "Fullscreen Integer Scaling"
+      },
+      "largeAddressAware": {
+        "long": "Large Address Aware (PROTON_FORCE_LARGE_ADDRESS_AWARE)",
+        "short": "Large Address Aware"
+      },
+      "oldGlString": {
+        "long": "Old GL String (PROTON_OLD_GL_STRING)",
+        "short": "Old GL String"
+      },
+      "useWineD3d11": {
+        "long": "Gebruik Wine D3D (PROTON_USE_WINED3D)",
+        "short": "Gebruik Wine D3D"
+      },
+      "useWineD9vk": {
+        "long": "Gebruik D9VK (PROTON_USE_D9VK)",
+        "short": "Gebruik D9VK"
+      }
+    },
+    "prompt": "Heb je deze Proton opties gebruikt?"
+  },
+  "launcher": {
+    "additionalNotes": {
+      "label": "Launcher"
+    },
+    "legend": "Launcher",
+    "options": {
+      "gamehub": {
+        "long": "Gamehub",
+        "short": "Gamehub"
+      },
+      "lutris": {
+        "long": "Lutris",
+        "short": "Lutris"
+      },
+      "notListed": {
+        "long": "Een andere launcher die niet in deze lijst staat",
+        "short": "Niet in deze lijst"
+      },
+      "steam": {
+        "long": "Steam",
+        "short": "Steam"
+      }
+    },
+    "prompt": "Hoe heb je dit spel opgestart?"
+  },
+  "localMultiplayerAppraisal": {
+    "prompt": "Hoe zou je de lokale multiplayer functionaliteit van het spel beoordelen? Beoordeel de volgende aspecten; vertragingsproblemen, invoer of connectieproblemen, etc."
+  },
+  "localMultiplayerAttempted": {
+    "prompt": "Heb je geprobeerd om lokale multiplayer te spelen (offline)?"
+  },
+  "localMultiplayerPlayed": {
+    "prompt": "Heb je lokale multiplayer werkend gekregen?"
+  },
+  "multiplayerAppraisal": {
+    "options": {
+      "acceptable": {
+        "long": "Acceptabel. Enkel problemen die de functionaliteit van het spel niet beïnvloeden.",
+        "short": "Acceptabel"
+      },
+      "awful": {
+        "long": "Zeer slecht. Praktisch onspeelbaar.",
+        "short": "Zeer slecht"
+      },
+      "excellent": {
+        "long": "Uitstekend. Geen problemen ondervonden.",
+        "short": "Uitstekend"
+      },
+      "good": {
+        "long": "Goed. Desondanks zeldzame problemen is het over het algemeen speelbaar.",
+        "short": "Goed"
+      },
+      "weak": {
+        "long": "Slecht. Er zijn problemen die de speelervaring aanzienlijk beïnvloeden.",
+        "short": "Slecht"
+      }
+    }
+  },
+  "onlineMultiplayerAppraisal": {
+    "prompt": "Hoe zou je de online multiplayer functionaliteit van het spel beoordelen? Beoordeel de volgende aspecten; vertragingsproblemen, invoer of connectieproblemen, matchmaking problemen, etc."
+  },
+  "onlineMultiplayerAttempted": {
+    "prompt": "Heb je geprobeerd om online multiplayer te spelen?"
+  },
+  "onlineMultiplayerPlayed": {
+    "prompt": "Kon je online multiplayer spelen?"
+  },
+  "opens": {
+    "legend": "Opstarten",
+    "prompt": "Kon je de game opstarten en het hoofdmenu bekijken?"
+  },
+  "performanceFaults": {
+    "legend": "Prestaties",
+    "options": {
+      "significantSlowdown": {
+        "long": "Zware prestatieproblemen",
+        "short": "Zware prestatieproblemen"
+      },
+      "slightSlowdown": {
+        "long": "Lichte prestatieproblemen",
+        "short": "Lichte prestatieproblemen"
+      }
+    },
+    "prompt": "Heb je onverwachte prestatieproblemen ervaren gezien je hardware?"
+  },
+  "prerequisites": {
+    "invalidOrMissingSystemInfo": "Systeeminformatie ontbreekt of is ongeldig",
+    "missingProfileInfo": "Profielinformatie is onvolledig. {{context}} ontbreekt",
+    "notLoggedIn": "Niet ingelogd met {{context}}"
+  },
+  "prerequisitesBlock": {
+    "action": "Ga naar mijn profiel",
+    "context": "Voordat je je recensie kan publiceren moet je inloggen met Steam en je systeeminformatie invullen.",
+    "headline": "Nog niet klaar om te publiceren!"
+  },
+  "preview": {
+    "intro": "Let op de volgende dingen:",
+    "notes": [
+      "Is je systeeminformatie recent? Je moet na elke update van je grafische stuurprogramma je Steam-informatie bijwerken.",
+      "Heb je het juiste spel geselecteerd? Sommige spellen hebben dezelfde naam maar meerdere versies (bijvoorbeeld GRID)",
+      "Heb je de beschrijvingen op de juiste plaats ingevuld? Schrijf bijvoorbeeld opmerkingen over beeldverstoringen in die specifieke sectie i.p.v. de 'extra opmerkingen' sectie."
+    ]
+  },
+  "prompts": {
+    "continuingDraft": "Je werkt verder vanaf een automatisch opgeslagen conceptversie.",
+    "discardDraftWarning": "Je antwoorden in deze conceptversie zullen voor eeuwig weggegooid worden.",
+    "startOver": "Begin opnieuw"
+  },
+  "protonVersion": {
+    "additionalNotes": {
+      "label": "Andere Proton-versie",
+      "placeholder": "Dit moet een geldige Proton-versie zijn. Voorbeelden: {{examples}}"
+    },
+    "prompt": "Welke versie van Proton gebruik je?"
+  },
+  "saveGameFaults": {
+    "legend": "Opgeslagen spellen",
+    "options": {
+      "errorLoading": {
+        "long": "Kon een opgeslagen spel niet laden",
+        "short": "Laden"
+      },
+      "errorSaving": {
+        "long": "Kon de spellen niet opslaan",
+        "short": "Opslaan"
+      },
+      "other": {
+        "long": "Ander probleem",
+        "short": "Ander probleem"
+      }
+    },
+    "prompt": "Ondervond je problemen met het opslaan van spellen?"
+  },
+  "significantBugs": {
+    "legend": "Problemen",
+    "prompt": "Ondervond je nog andere belangrijke problemen?"
+  },
+  "stabilityFaults": {
+    "legend": "Stabiliteit",
+    "options": {
+      "frequentCrashes": {
+        "long": "Het kwam vaak voor dat het spel vastliep",
+        "short": "Vaak"
+      },
+      "notListed": {
+        "long": "Een ander stabiliteitsprobleem wat niet in deze lijst staat",
+        "short": "Niet in deze lijst"
+      },
+      "occasionally": {
+        "long": "Van tijd tot tijd liep het spel vast",
+        "short": "Soms"
+      }
+    },
+    "prompt": "Heb je stabiliteitsproblemen ondervonden?"
+  },
+  "startsPlay": {
+    "legend": "Opstarten van het spel",
+    "prompt": "Kon je met het spel beginnen?"
+  },
+  "stepHeadlines": {
+    "appSelection": "Spelselectie",
+    "borked": "Onspeelbaar!",
+    "customizations": "Aanpassingen",
+    "finalNotes": "Oordeel",
+    "gameplay": "Andere mogelijke problemen",
+    "graphics": "Grafisch en Prestaties",
+    "multiplayer": "Multiplayer",
+    "preview": "Voorbeeld",
+    "setup": "Instellingen",
+    "stability": "Stabiliteit",
+    "startup": "Installatie en Opstarten",
+    "tinkerCheck": "Recensietype",
+    "unownedWarning": "Niet in jouw bibliotheek"
+  },
+  "type": {
+    "intro": [
+      "ProtonDB verdeelt recensies nu in twee soorten: Steam Play en Tinker.",
+      "Gebruik Steam Play Recensie om de out-of-de-box-ervaring te beschrijven. Installeer het spel, druk op 'Play', en start het spel.",
+      "Gebruik Tinker Recensie als je aanpassingen gedaan hebt om het spel werkend te krijgen.",
+      "Voor meer informatie over de verschillen, zie [dit nieuwsartikel]({{link}})."
+    ],
+    "options": {
+      "steamPlay": {
+        "long": "SteamPlay Recensie",
+        "short": "SteamPlay Recensie"
+      },
+      "tinker": {
+        "long": "Tinker Recensie",
+        "short": "Tinker Recensie"
+      }
+    },
+    "prompt": "Welk type recensie wil je schrijven?"
+  },
+  "verdict": {
+    "additionalNotes": {
+      "label": "Samenvatting (max {{count}} karakters)",
+      "placeholder": "Voeg een korte samenvatting van je ervaring toe. Dit zal de kop van je recensie worden."
+    },
+    "prompt": "Zou een typische gamer een goede ervaring hebben als hij dit spel op Linux met Proton speelt?"
+  },
+  "welcome": {
+    "headline": "Welkom",
+    "intro": "Bedankt voor je interesse om bij te dragen aan ProtonDB's catalogus van compatibiliteitsrecensies. Houd rekening met het volgende voordat u bijdraagt:",
+    "notes": [
+      "Recensies zijn ervoor om jou, Valve, en spelontwikkelaars te helpen om spellen te repareren. Wij vragen je om je recensies nauwkeurig te houden en geen beledigend taalgebruik in je recensies te gebruiken. Ook is het niet de bedoeling dat je je favoriete game, Linux-distributie of grafische kaart promoot.",
+      "Het is aanbevolen om over verloop van tijd meerdere recensies voor hetzelfde spel te publiceren. Zo krijgen we inzicht in de verbetering/verslechtering van de compatibiliteit van een spel.",
+      "Als je meerdere recensies publiceert zal alleen je laatste recensie meetellen tot de ProtonDB beoordeling. Als jouw systeem niet voldoet aan Proton's minimumvereisten wordt je recensie niet meegeteld tot deze beoordeling.",
+      "Your contributions will be publicly visible on ProtonDB and available in data exports under the Open Database License. Go [here]({{link}}) for more information.",
+      "Jouw recensies zullen openbaar te zien zijn op ProtonDB en ook geëxporteerd worden in data exports onder de Open Database Licentie. Klik [hier]({{link}}) voor meer informatie."
+    ],
+    "outro": "Laten we beginnen!"
+  },
+  "windowingFaults": {
+    "legend": "Venster",
+    "options": {
+      "activatingFullscreen": {
+        "long": "Volledig scherm kon niet geactiveerd worden",
+        "short": "Volledig scherm werkt niet"
+      },
+      "fullNotFull": {
+        "long": "Volledig scherm vulde niet het gehele beeldscherm",
+        "short": "Volledig scherm vulde niet het gehele beeldscherm"
+      },
+      "other": {
+        "long": "Ander probleem",
+        "short": "Ander probleem"
+      },
+      "switching": {
+        "long": "Could not conventionally escape from fullscreen (such as with Alt-Tab)",
+        "short": "Alt+Tab werkt niet"
+      }
+    },
+    "prompt": "Heb je problemen ondervonden met het gebruik van de volledig scherm modus of het gebruik van een venster?"
+  }
+}

--- a/locales/nl-NL/proton-report.json
+++ b/locales/nl-NL/proton-report.json
@@ -5,7 +5,7 @@
     "notFound": "Er kan geen spel gevonden worden met App ID {{query}}. Dit kan gebeuren als het ID ongeldig is of om één van de volgende redenen; het spel is verwijderd van de Steam winkel, het is niet als een 'game' getypeerd, of het is niet beschikbaar in jouw land.",
     "placeholder": "Voer een naam in van een spel uit jouw Steam-bibliotheek...",
     "previousReportsExist": "Je hebt al eerder een recensie over dit spel geschreven",
-    "runsNativeWarning": "Het geselecteerde spel ondersteunt Linux! Zorg ervoor dat u het spel met Steam Play uitvoert en niet met de standaard Linux-ondersteunende versie. Steam gebruikt standaard niet Steam Play om het spel te starten, maar [je kan dit wel dwingen]({{link}})."
+    "runsNativeWarning": "Het geselecteerde spel ondersteunt Linux! Zorg ervoor dat je het spel met Steam Play uitvoert en niet met de standaard Linux-ondersteunende versie. Steam gebruikt standaard niet Steam Play om het spel te starten, maar [je kan dit wel dwingen]({{link}})."
   },
   "audioFaults": {
     "legend": "Audio",
@@ -85,7 +85,7 @@
         "short": "winetricks"
       }
     },
-    "prompt": "Welke aanpassing(en) heb je gemaakt?"
+    "prompt": "Welke aanpassing(en) had je gemaakt?"
   },
   "duration": {
     "legend": "Speelduur",
@@ -118,7 +118,7 @@
       "label": "Extra opmerkingen",
       "placeholder": "Voer hier opmerkingen in."
     },
-    "prompt": "Heeft u opmerkingen die u zou willen toevoegen die nog niet in eerdere vragen behandeld zijn?"
+    "prompt": "Heb je opmerkingen die je zou willen toevoegen die nog niet in eerdere vragen behandeld zijn?"
   },
   "graphicalFaults": {
     "legend": "Beeld",
@@ -140,7 +140,7 @@
         "short": "Ander probleem"
       }
     },
-    "prompt": "Heeft u vermindering van grafische kwaliteit opgemerkt?"
+    "prompt": "Had je vermindering van grafische kwaliteit opgemerkt?"
   },
   "graphicsApiSelection": {
     "legend": "Grafische API",
@@ -222,7 +222,7 @@
         "short": "Andere anti-cheat"
       }
     },
-    "prompt": "Wordt het spel gehinderd door anti-cheat software?"
+    "prompt": "Wordt het spel negatief beïnvloed of op een andere manier gehinderd door anti-cheat software?"
   },
   "isMultiplayerImportant": {
     "prompt": "Is multiplayer een belangrijk aspect van het spel?"
@@ -271,7 +271,7 @@
         "short": "Gebruik D9VK"
       }
     },
-    "prompt": "Heb je deze Proton opties gebruikt?"
+    "prompt": "Had je deze Proton opties gebruikt?"
   },
   "launcher": {
     "additionalNotes": {
@@ -296,7 +296,7 @@
         "short": "Steam"
       }
     },
-    "prompt": "Hoe heb je dit spel opgestart?"
+    "prompt": "Hoe had je dit spel opgestart?"
   },
   "localMultiplayerAppraisal": {
     "prompt": "Hoe zou je de lokale multiplayer functionaliteit van het spel beoordelen? Beoordeel de volgende aspecten; vertragingsproblemen, invoer of connectieproblemen, etc."
@@ -356,7 +356,7 @@
         "short": "Lichte prestatieproblemen"
       }
     },
-    "prompt": "Heb je onverwachte prestatieproblemen ervaren gezien je hardware?"
+    "prompt": "Had je onverwachte prestatieproblemen ervaren gezien je hardware?"
   },
   "prerequisites": {
     "invalidOrMissingSystemInfo": "Systeeminformatie ontbreekt of is ongeldig",
@@ -426,14 +426,14 @@
         "short": "Soms"
       }
     },
-    "prompt": "Heb je stabiliteitsproblemen ondervonden?"
+    "prompt": "Had je stabiliteitsproblemen ondervonden?"
   },
   "startsPlay": {
     "legend": "Opstarten van het spel",
     "prompt": "Kon je met het spel beginnen?"
   },
   "stepHeadlines": {
-    "appSelection": "Spelselectie",
+    "appSelection": "Selecteer een spel",
     "borked": "Onspeelbaar!",
     "customizations": "Aanpassingen",
     "finalNotes": "Oordeel",
@@ -449,8 +449,8 @@
   },
   "type": {
     "intro": [
-      "ProtonDB verdeelt recensies nu in twee soorten: Steam Play en Tinker.",
-      "Gebruik Steam Play Recensie om de out-of-de-box-ervaring te beschrijven. Installeer het spel, druk op 'Play', en start het spel.",
+      "ProtonDB verdeelt recensies onder in twee soorten: Steam Play en Tinker.",
+      "Gebruik Steam Play Recensie om de out-of-de-box-ervaring te beschrijven. Doe die alleen als je geen aanpassingen hebt gedaan.",
       "Gebruik Tinker Recensie als je aanpassingen gedaan hebt om het spel werkend te krijgen.",
       "Voor meer informatie over de verschillen, zie [dit nieuwsartikel]({{link}})."
     ],
@@ -475,9 +475,9 @@
   },
   "welcome": {
     "headline": "Welkom",
-    "intro": "Bedankt voor je interesse om bij te dragen aan ProtonDB's catalogus van compatibiliteitsrecensies. Houd rekening met het volgende voordat u bijdraagt:",
+    "intro": "Bedankt voor je interesse om bij te dragen aan ProtonDB's catalogus van compatibiliteitsrecensies. Houd rekening met het volgende voordat je een recensie gaat schrijven:",
     "notes": [
-      "Recensies zijn ervoor om jou, Valve, en spelontwikkelaars te helpen om spellen te repareren. Wij vragen je om je recensies nauwkeurig te houden en geen beledigend taalgebruik in je recensies te gebruiken. Ook is het niet de bedoeling dat je je favoriete game, Linux-distributie of grafische kaart promoot.",
+      "Recensies zijn ervoor om jou, Valve, en spelontwikkelaars te helpen om spellen te repareren. Wij vragen je om jouw recensies nauwkeurig te houden en geen beledigend taalgebruik in je recensies te gebruiken. Ook is het niet de bedoeling dat je je favoriete game, Linux-distributie of grafische kaart promoot.",
       "Het is aanbevolen om over verloop van tijd meerdere recensies voor hetzelfde spel te publiceren. Zo krijgen we inzicht in de verbetering/verslechtering van de compatibiliteit van een spel.",
       "Als je meerdere recensies publiceert zal alleen je laatste recensie meetellen tot de ProtonDB beoordeling. Als jouw systeem niet voldoet aan Proton's minimumvereisten wordt je recensie niet meegeteld tot deze beoordeling.",
       "Your contributions will be publicly visible on ProtonDB and available in data exports under the Open Database License. Go [here]({{link}}) for more information.",
@@ -501,10 +501,10 @@
         "short": "Ander probleem"
       },
       "switching": {
-        "long": "Could not conventionally escape from fullscreen (such as with Alt-Tab)",
+        "long": "Met Alt+Tab kon je niet overschakelen naar een ander venster",
         "short": "Alt+Tab werkt niet"
       }
     },
-    "prompt": "Heb je problemen ondervonden met het gebruik van de volledig scherm modus of het gebruik van een venster?"
+    "prompt": "Had je problemen ondervonden met het gebruik van de volledig scherm modus of het gebruik van een venster?"
   }
 }

--- a/locales/nl-NL/proton-report.json
+++ b/locales/nl-NL/proton-report.json
@@ -415,7 +415,7 @@
     "options": {
       "frequentCrashes": {
         "long": "Het kwam vaak voor dat het spel vastliep",
-        "short": "Vaak"
+        "short": "Loopt vaak vast"
       },
       "notListed": {
         "long": "Een ander stabiliteitsprobleem wat niet in deze lijst staat",
@@ -423,7 +423,7 @@
       },
       "occasionally": {
         "long": "Van tijd tot tijd liep het spel vast",
-        "short": "Soms"
+        "short": "Loopt soms vast"
       }
     },
     "prompt": "Had je stabiliteitsproblemen ondervonden?"

--- a/locales/nl-NL/protondb-content.json
+++ b/locales/nl-NL/protondb-content.json
@@ -16,7 +16,7 @@
       "vr": "Virtual Reality"
     },
     "unavailable": "Niet beschikbaar",
-    "unrated": "Niet beoordeeld",
+    "unrated": "Onbeoordeeld",
     "unreported": "Niet gerecenseerd"
   },
   "explore": {

--- a/locales/nl-NL/protondb-content.json
+++ b/locales/nl-NL/protondb-content.json
@@ -5,9 +5,9 @@
   "breakdown": {
     "headline": "Populaire Spellen",
     "popularHeadline": "Beoordelingen voor de {{count}} meest populaire",
-    "topHundred": "Top Honderd",
-    "topTen": "Top Tien",
-    "topThousand": "Top Duizend",
+    "topHundred": "Top 100",
+    "topTen": "Top 10",
+    "topThousand": "Top 1000",
     "topics": {
       "allGames": "Alle Spellen",
       "indie": "Indie",
@@ -72,7 +72,7 @@
     "githubIssueSearch": "Github Issue Search",
     "infoNotFound": "Fout bij het ophalen van informatie over App ID: {{entry}}. Dit kan gebeuren als het spel verwijderd is van de Steam store.",
     "minimumRequirements": "Minimumvereisten",
-    "nativelySupports": "Ondersteunt Natively"
+    "nativelySupports": "Ondersteunt natively"
   },
   "home": {
     "getStartedLinks": [

--- a/locales/nl-NL/protondb-content.json
+++ b/locales/nl-NL/protondb-content.json
@@ -1,0 +1,173 @@
+{
+  "auth": {
+    "intro": "Als je inlogt met Steam kun je recensies publiceren en de [Ontdek-pagina met bibliotheekfilter]({{link}}) gebruiken om de resultaten tot je eigen Steam-bibliotheek te beperken."
+  },
+  "breakdown": {
+    "headline": "Populaire Spellen",
+    "popularHeadline": "Beoordelingen voor de {{count}} meest populaire",
+    "topHundred": "Top Honderd",
+    "topTen": "Top Tien",
+    "topThousand": "Top Duizend",
+    "topics": {
+      "allGames": "Alle Spellen",
+      "indie": "Indie",
+      "localMultiplayer": "Lokale Multiplayer",
+      "singlePlayer": "Single Player",
+      "vr": "Virtual Reality"
+    },
+    "unavailable": "Niet beschikbaar",
+    "unrated": "Niet beoordeeld",
+    "unreported": "Niet gerecenseerd"
+  },
+  "explore": {
+    "headlines": {
+      "fixWanted": "Reparatie nodig",
+      "highestRated": "Hoogst beoordeeld op SteamDB",
+      "hoursPlayed": "Uren gespeeld",
+      "inLibrary": "In bibliotheek",
+      "mostBorked": "Meest onspeelbaar",
+      "mostPopular": "Meest populair",
+      "recentlyImproved": "Recent verbeterd",
+      "wellRatedHere": "Hier goed beoordeeld"
+    },
+    "layout": "Opmaak",
+    "loadError": "Fout bij het laden van jouw spellen!",
+    "notLoggedIn": "De bibliotheek kan niet zonder Steam ID geladen worden. Voeg een ID toe in je [Profiel]({{link}})",
+    "poweredBy": "Ondersteund door",
+    "sorts": {
+      "fixWanted": "Reparatie nodig",
+      "hoursPlayed": "Uren gespeeld",
+      "mostBorked": "Meest onspeelbaar",
+      "playerCount": "Speleraantal",
+      "recentlyImproved": "Recent verbeterd",
+      "userScore": "Gebruikersbeoordeling",
+      "wilsonRating": "ProtonDB-Beoordeling"
+    },
+    "toggles": {
+      "includeNative": "Native ondersteund laten zien",
+      "lackReports": "Gebrek aan recensies",
+      "restrictToLibrary": "Beperken tot bibliotheek",
+      "untested": "Gebrek aan recensies",
+      "userTags": "Gebruikersomschrijvingen",
+      "whitelisted": "Whitelisted"
+    }
+  },
+  "filters": {
+    "questions": {
+      "cpu": {
+        "label": "CPU"
+      },
+      "distro": {
+        "label": "Distributie"
+      },
+      "gpu": {
+        "label": "GPU"
+      },
+      "type": {
+        "label": "Type"
+      }
+    }
+  },
+  "gameDetails": {
+    "githubIssueSearch": "Github Issue Search",
+    "infoNotFound": "Fout bij het ophalen van informatie over App ID: {{entry}}. Dit kan gebeuren als het spel verwijderd is van de Steam store.",
+    "minimumRequirements": "Minimumvereisten",
+    "nativelySupports": "Ondersteunt Natively"
+  },
+  "home": {
+    "getStartedLinks": [
+      "[Steam's Officiële Steam Play pagina](https://store.steampowered.com/steamplay)",
+      "[Een handleiding voor het migreren naar Linux](https://www.reddit.com/r/linux_gaming/comments/9oqq3w/guide_migrating_to_linux_in_2019/)",
+      "[Wat is Vulkan?](https://www.reddit.com/r/linux_gaming/comments/9ritk1/not_sure_i_quite_understand_can_someone_explain/)"
+    ],
+    "headline": "Met Proton en Steam Play werken vele Windows spellen nu ook op Linux!",
+    "howDoIHelp": {
+      "answer": "Probeer Linux een keer! Maak je geen zorgen als je nieuw bent. Hier is een lijst met handleidingen om je van start te helpen. Als je wilt helpen om Valve en Proton beter te maken kun je hier op ProtonDB recensies over jouw speelervaringen publiceren.",
+      "question": "Cool! Hoe kan ik meehelpen?"
+    },
+    "letsGetStarted": "Laten we beginnen.",
+    "sampleGames": "Hier is een lijst met populaire spellen die nog niet officieël erkend zijn door Valve, maar die wel veel Platinum recensies hebben gekregen op ProtonDB",
+    "search": "Zoek voor een spel...",
+    "stats": {
+      "gamesReported": "spellen gerecenseerd",
+      "gamesWork": "spellen werken",
+      "reportsWritten": "recensies geschreven"
+    },
+    "theImpact": {
+      "answer": "Steam Play ondersteunt op dit moment een kleine maar groeiende groep 'erkende' spellen die goed speelbaar zijn op Linux met behulp van Proton. Uit de recensies op ProtonDB blijkt dat een groot aantal niet erkende spellen, waaronder veel populaire titels, net zo goed op Linux draaien als op Windows.",
+      "question": "De Impact"
+    },
+    "whatIsProton": {
+      "answer": "Proton is een nieuwe technologie uitgegeven door Valve Software waarmee je spellen die alleen voor Windows gemaakt zijn net zo makkelijk op Linux kan spelen. Omdat het geïntegreerd is met Steam Play hoef je alleen maar op de 'Play' knop te drukken om deze spellen te starten. Onder de motorkap bestaat Proton uit andere populaire tools zoals Wine en DXVK die automatisch geïnstalleerd en geupdatet worden. Hierdoor hoeft de gebruiker niet technisch onderlegd te zijn om over te schakelen naar Linux. Omdat Proton nog in de kinderschoenen staat kunnen er nog kinderziektes optreden, maar hier wordt hard aan gewerkt.",
+      "question": "Wat is Proton?"
+    },
+    "whatIsProtonDb": {
+      "answer": "Het doel van ProtonDB is om recensies te verzamelen van gamers over de hele wereld die spellen testen met Proton op Linux. Op basis van deze recensies worden beoordelingen vastgesteld met betrekking tot hoe goed de spellen ondersteund zijn. Ook kunnen gebruikers aanpassingen delen die ze gemaakt hebben om een spel met success te kunnen spelen. Je kunt ook de Steam spelcatalogus verkennen en een hoop spellen ontdekken die eerder nooit op Linux uitgebracht waren.",
+      "question": "Wat is ProtonDB?"
+    },
+    "whyBigDeal": {
+      "answer": "De Linux desktop experience is de laatste jaren erg verbeterd. Het grotendeel van wat je op Windows of MacOS kunt doen is hedendaags ook mogelijk op Linux zonder veel kennis te hebben van Linux. ",
+      "question": "Waarom is dit zo belangrijk?"
+    },
+    "youtubeId": "Co6FePZoNgE"
+  },
+  "medals": {
+    "borked": "Onspeelbaar",
+    "bronze": "Brons",
+    "gold": "Goud",
+    "platinum": "Platina",
+    "silver": "Zilver"
+  },
+  "ratingDefinitions": {
+    "explanations": {
+      "borked": "Het spel start niet op of heeft ernstige gebreken",
+      "bronze": "Werkt redelijk, maar heeft enkele problemen of loopt soms vast",
+      "gold": "Werkt perfect met enkele aanpassingen",
+      "native": "Wordt natively ondersteund op Linux",
+      "pending": "Nog niet genoeg recensies om een beoordeling te geven",
+      "platinum": "Werkt perfect zonder extra aanpassingen",
+      "silver": "Is speelbaar, maar heeft enkele gebreken"
+    },
+    "headline": "Uitleg over de ondersteuningsniveaus"
+  },
+  "specs": {
+    "cpu": "CPU",
+    "gpu": "GPU",
+    "gpuDriver": "GPU-Stuurprogramma",
+    "kernel": "Kernel",
+    "os": "Distributie",
+    "otherSpecs": "Andere specificaties",
+    "ram": "RAM-Geheugen"
+  },
+  "stats": {
+    "analysisInByTheNumbers1": "Analysis in By The Numbers #1",
+    "byCommonDisplayDrivers": "Op overeenkomende GPU stuurprogrammas",
+    "byDistro": "Op Distributie",
+    "byGpu": "Op GPU",
+    "byProtonVersion": "Op Proton-versie",
+    "dailyReportsHeadline": "Dagelijkse recensies (laatste {{days}} dagen)",
+    "downloadData": "Gegevens downloaden",
+    "gameRatingDistribution": "Verdeling van de spelrecensies",
+    "gamesWithNOrMoreReports": "Spellen met N of meer recensies",
+    "reportRatingDistributionOverTime": "Verspreiding van recensies in verloop van tijd",
+    "whenMeetingMinimumRequirements": "Wanneer het voldoet aan de minimumvereisten"
+  },
+  "steamAuthor": {
+    "hoursInSteam": "{{count}} uren op Steam",
+    "timeWithProton": "{{time}} met Proton"
+  },
+  "suggestions": {
+    "headline": "Ben je klaar voor meer?",
+    "intro": "De volgende spellen zijn geselecteerd op basis hun populariteit, SteamDB score, en op jouw speelduur. Ze hebben allemaal nog recensies nodig en sommigen hebben er misschien nog maar één nodig om een {{siteName}} beoordeling te krijgen! Om meer suggesties te krijgen kun je deze pagina herladen of het [Gebrek aan recensies]({{link}}) filter op de Ondek-pagina gebruiken."
+  },
+  "systemInfo": {
+    "headline": "Systeeminformatie",
+    "howTo": "Ga naar de Steam-instellingen en kopieer jouw systeeminformatie. Plak deze tekst in het invoerveld hieronder. [Klik hier voor meer uitleg (in het Engels)]({{link}}). (Sommige gebruikers hebben opgemerkt dat ze eerst Ctrl-A moeten indrukken om alles te selecteren voordat ze de tekst kunnen kopieren.)",
+    "intro": "Recensies zijn betrouwbaarder als de auteur aangeeft op welke hardware en software het spel getest was. Om deze informatie zo consequent mogelijk te houden gebruiken wij de systeeminformatie die Steam zelf aangeeft.",
+    "parseFailure": "Fout bij het lezen van jouw systeeminformatie. Als je zeker weet dat je het correct gekopieerd hebt, laat het ons dan weten op Discord",
+    "parseSuccess": "Systeeminformatie met success ingelezen!",
+    "pasteInstructions": "Plak hier jouw Steam systeeminformatie",
+    "unsupportedHeadline": "Jouw stuurprogrammas worden niet ondersteund",
+    "unsupportedWarning": "Het grafische stuurprogramma dat op jouw systeem geïnstalleerd is voldoet niet aan [Proton's minimumvereisten]({{link}})! Het is mogelijk dat je spellen vastlopen, langzamer dan gewenst lopen, of dat er beeldverstoringen optreden. Je kan nog wel recensies schrijven, maar naast je recensie wordt je systeeminformatie in rode tekstkleur weergegeven en je beoordeling wordt niet meegeteld voor de totale score van het spel. Werk a.u.b. je stuurprogramma bij!"
+  }
+}

--- a/locales/nl-NL/protondb-content.json
+++ b/locales/nl-NL/protondb-content.json
@@ -82,12 +82,12 @@
     ],
     "headline": "Met Proton en Steam Play werken vele Windows spellen nu ook op Linux!",
     "howDoIHelp": {
-      "answer": "Probeer Linux een keer! Maak je geen zorgen als je nieuw bent. Hier is een lijst met handleidingen om je van start te helpen. Als je wilt helpen om Valve en Proton beter te maken kun je hier op ProtonDB recensies over jouw speelervaringen publiceren.",
+      "answer": "Probeer Linux een keer! Maak je geen zorgen als je nieuw bent. Je kunt hieronder een lijst met handleidingen vinden om je van start te helpen. Als je wilt helpen om Valve en Proton beter te maken kun je hier op ProtonDB recensies over jouw speelervaringen indienen.",
       "question": "Cool! Hoe kan ik meehelpen?"
     },
     "letsGetStarted": "Laten we beginnen.",
     "sampleGames": "Hier is een lijst met populaire spellen die nog niet officieël erkend zijn door Valve, maar die wel veel Platinum recensies hebben gekregen op ProtonDB",
-    "search": "Zoek voor een spel...",
+    "search": "Zoek naar een spel...",
     "stats": {
       "gamesReported": "spellen gerecenseerd",
       "gamesWork": "spellen werken",
@@ -98,15 +98,15 @@
       "question": "De Impact"
     },
     "whatIsProton": {
-      "answer": "Proton is een nieuwe technologie uitgegeven door Valve Software waarmee je spellen die alleen voor Windows gemaakt zijn net zo makkelijk op Linux kan spelen. Omdat het geïntegreerd is met Steam Play hoef je alleen maar op de 'Play' knop te drukken om deze spellen te starten. Onder de motorkap bestaat Proton uit andere populaire tools zoals Wine en DXVK die automatisch geïnstalleerd en geupdatet worden. Hierdoor hoeft de gebruiker niet technisch onderlegd te zijn om over te schakelen naar Linux. Omdat Proton nog in de kinderschoenen staat kunnen er nog kinderziektes optreden, maar hier wordt hard aan gewerkt.",
+      "answer": "Proton is een nieuwe technologie uitgegeven door Valve Software waarmee je spellen die alleen voor Windows gemaakt zijn net zo makkelijk op Linux kan spelen. Omdat het geïntegreerd is met Steam Play hoef je alleen maar op de 'Play' knop te drukken om deze spellen te starten. Onder de motorkap bestaat Proton uit andere populaire tools zoals Wine en DXVK die automatisch geïnstalleerd en geupdatet worden. Hierdoor hoeft de gebruiker niet technisch onderlegd te zijn om over te schakelen van Windows naar Linux. Omdat Proton nog in de kinderschoenen staat kunnen er nog problemen optreden, maar hier wordt hard aan gewerkt.",
       "question": "Wat is Proton?"
     },
     "whatIsProtonDb": {
-      "answer": "Het doel van ProtonDB is om recensies te verzamelen van gamers over de hele wereld die spellen testen met Proton op Linux. Op basis van deze recensies worden beoordelingen vastgesteld met betrekking tot hoe goed de spellen ondersteund zijn. Ook kunnen gebruikers aanpassingen delen die ze gemaakt hebben om een spel met success te kunnen spelen. Je kunt ook de Steam spelcatalogus verkennen en een hoop spellen ontdekken die eerder nooit op Linux uitgebracht waren.",
+      "answer": "Het doel van ProtonDB is om recensies te verzamelen van gamers die spellen testen met Proton op Linux. Op basis van deze recensies wordt de mate van ondersteuning van deze spellen beoordeeld. Ook kunnen gebruikers aanpassingen delen die ze gemaakt hebben om een spel met success te kunnen spelen. Je kunt ook de Steam spelcatalogus verkennen en een hoop spellen ontdekken die nooit op Linux uitgebracht zijn.",
       "question": "Wat is ProtonDB?"
     },
     "whyBigDeal": {
-      "answer": "De Linux desktop experience is de laatste jaren erg verbeterd. Het grotendeel van wat je op Windows of MacOS kunt doen is hedendaags ook mogelijk op Linux zonder veel kennis te hebben van Linux. ",
+      "answer": "De Linux desktop is de laatste jaren erg verbeterd. Het grotendeel van wat je op Windows of MacOS kunt doen is hedendaags ook mogelijk op Linux zonder veel kennis te hebben van Linux. Het enige obstakel wat Linux users nog in de weg staat is gaming. We hopen gamen makkelijker te maken met Proton en Steam Play.",
       "question": "Waarom is dit zo belangrijk?"
     },
     "youtubeId": "Co6FePZoNgE"
@@ -128,7 +128,7 @@
       "platinum": "Werkt perfect zonder extra aanpassingen",
       "silver": "Is speelbaar, maar heeft enkele gebreken"
     },
-    "headline": "Uitleg over de ondersteuningsniveaus"
+    "headline": "uitleg over de ondersteuningsniveaus"
   },
   "specs": {
     "cpu": "CPU",
@@ -140,7 +140,7 @@
     "ram": "RAM-Geheugen"
   },
   "stats": {
-    "analysisInByTheNumbers1": "Analysis in By The Numbers #1",
+    "analysisInByTheNumbers1": "Het volledige onderzoek is te lezen in het nieuwsbericht 'By The Numbers #1'",
     "byCommonDisplayDrivers": "Op overeenkomende GPU stuurprogrammas",
     "byDistro": "Op Distributie",
     "byGpu": "Op GPU",
@@ -149,7 +149,7 @@
     "downloadData": "Gegevens downloaden",
     "gameRatingDistribution": "Verdeling van de spelrecensies",
     "gamesWithNOrMoreReports": "Spellen met N of meer recensies",
-    "reportRatingDistributionOverTime": "Verspreiding van recensies in verloop van tijd",
+    "reportRatingDistributionOverTime": "Verdeling van recensies in verloop van tijd",
     "whenMeetingMinimumRequirements": "Wanneer het voldoet aan de minimumvereisten"
   },
   "steamAuthor": {

--- a/locales/nl-NL/questionnaire.json
+++ b/locales/nl-NL/questionnaire.json
@@ -1,0 +1,20 @@
+{
+  "genericFollowUpPrompt": "Welk soort problemen?",
+  "misc": {
+    "answerRequired": "Je moet hierop antwoord geven",
+    "answerRequiredWhenNotListed": "Je moet een antwoord geven als je 'Niet in deze lijst' hebt gekozen",
+    "back": "Terug",
+    "error": "Fout!",
+    "markdownSupportNotice": "Markdown wordt nu ondersteund",
+    "maxChars": "Maximaal {{count}} karakters",
+    "next": "Volgende",
+    "submission": {
+      "error": "Er trad een fout op tijdens het indienen van jouw inzending. Zorg dat je browser oproepen naar apis.google.com niet blokkeert. Brave browser en Privacy Badger blokkeren deze standaard al. Laat ons weten als je ondanks deze maatregelen nog steeds niet kan indienen!",
+      "note": "Houd er rekening mee dat nieuwe recensies tot de volgende verversing in de wacht worden gezet. Je kan jouw inzendingen bekijken op je [Profiel]({{link}})",
+      "success": "Met success ingediend",
+      "thanks": "Bedankt voor jouw inzending naar {{siteName}}"
+    },
+    "submit": "Indienen",
+    "tooLong": "Te lang"
+  }
+}

--- a/locales/nl-NL/questionnaire.json
+++ b/locales/nl-NL/questionnaire.json
@@ -5,7 +5,7 @@
     "answerRequiredWhenNotListed": "Je moet een antwoord geven als je 'Niet in deze lijst' hebt gekozen",
     "back": "Terug",
     "error": "Fout!",
-    "markdownSupportNotice": "Markdown wordt nu ondersteund",
+    "markdownSupportNotice": "Markdown wordt ook ondersteund",
     "maxChars": "Maximaal {{count}} karakters",
     "next": "Volgende",
     "submission": {


### PR DESCRIPTION
I've only noticed one issue with this translation: the text in the tier breakdown chart does not fit.
![Screenshot from 2020-09-29 14-29-47](https://user-images.githubusercontent.com/32428346/94559011-e8284000-0260-11eb-907e-baaa04c54e14.png)
It can't be worded any shorter, maybe there's an alternative fix?