### PR TITLE
Changed 'Gryo' to 'Gyro'

### DIFF
--- a/locales/en-US/proton-report.json
+++ b/locales/en-US/proton-report.json
@@ -113,7 +113,7 @@
       },
       "gyro": {
         "long": "Enabled Gyro",
-        "short": "Gryo"
+        "short": "Gyro"
       },
       "other": {
         "long": "Other",


### PR DESCRIPTION
Found a typo when browsing, where it said 'Gryo' instead of 'Gyro' in the reports. Changed this on line 116.